### PR TITLE
feat: Phase 1A — Vitest testing foundation + roadmap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,283 @@
+# Questive Roadmap
+
+## Overview
+
+Three pillars: (1) Production readiness, (2) AI-powered task breakdowns, (3) Complementary features.
+
+---
+
+## Pillar 1: Production Readiness
+
+### Phase 1A: Testing Foundation
+
+**Framework: Vitest** (not Jest — native ESM, 3-5x faster, works with Next.js 16 + React 19 out of the box)
+
+**Install:**
+```
+devDependencies: vitest @vitest/coverage-v8 @vitest/ui @testing-library/react @testing-library/jest-dom @testing-library/user-event jsdom
+```
+
+**Create:**
+- `vitest.config.ts` — coverage thresholds at 95% (statements, branches, functions, lines), exclude `components/ui/**` (shadcn vendor code)
+- `vitest.workspace.ts` — separate `unit` (jsdom) and `integration` (node) projects
+- `tests/setup.ts` — RTL cleanup + jest-dom matchers
+- `tests/helpers/mock-auth.ts` — shared `vi.mock('@/lib/auth')` with configurable session
+- `tests/helpers/mock-db.ts` — Prisma client mock factory for all models
+- `tests/helpers/mock-ai.ts` — Gemini model mock returning structured JSON
+- `tests/helpers/render-with-providers.tsx` — custom render with SessionProvider + ThemeProvider
+
+**Test structure:**
+```
+tests/
+├── setup.ts
+├── helpers/                    # Shared mocks
+├── unit/
+│   ├── lib/                   # utils, auth, db, ai/gemini
+│   └── actions/               # All 7 server action files
+├── components/                # Component tests (forms, taskboard, ai, settings, dashboard)
+├── integration/               # Real DB tests (goal lifecycle, task board flow, AI flow)
+└── e2e/
+    └── smoke.test.ts          # Production canary (HTTP checks against live URL)
+```
+
+**Server action testing approach:** Mock `@/lib/auth`, `@/lib/db`, `next/cache` via `vi.mock()`. Test: auth guard, ownership checks, CRUD correctness, revalidation calls. AI actions additionally mock `@/lib/ai/gemini`.
+
+**Component testing approach:** React Testing Library with custom render wrapper. Focus on interactive components (forms, dialogs, task board). Skip shadcn/ui vendor components.
+
+**Integration tests:** Real PostgreSQL via Docker (existing `docker-compose.yml`). Mock only auth. Test multi-step flows (create category → goal → milestone → complete).
+
+**Scripts to add to `package.json`:**
+```json
+"test": "vitest run --project unit",
+"test:watch": "vitest --project unit",
+"test:coverage": "vitest run --project unit --coverage",
+"test:integration": "vitest run --project integration",
+"test:smoke": "vitest run tests/e2e/smoke.test.ts",
+"typecheck": "tsc --noEmit"
+```
+
+### Phase 1B: CI/CD Pipeline
+
+**Pre-commit hooks:**
+- Install `husky` + `lint-staged` (dev)
+- `.husky/pre-commit` → `npx lint-staged` (ESLint fix + related tests)
+- `.husky/pre-push` → `npm run typecheck`
+
+**GitHub Actions `.github/workflows/ci.yml`:**
+
+| Job | Trigger | What |
+|-----|---------|------|
+| `lint-and-typecheck` | push + PR | `npm run lint` + `tsc --noEmit` |
+| `unit-tests` | push + PR | `vitest run --project unit --coverage` + post coverage report on PR |
+| `integration-tests` | push + PR | Postgres service container + `vitest run --project integration` |
+| `build` | push + PR (needs lint + unit) | `npm run build` |
+| `smoke-tests` | main only (post-deploy) | Run `tests/e2e/smoke.test.ts` against production URL |
+
+Coverage enforcement: `davelosert/vitest-coverage-report-action` posts coverage summary on PRs, fails if below 95%.
+
+### Phase 1C: Monitoring & Observability
+
+**Error tracking — Sentry:**
+- Install `@sentry/nextjs`
+- Create `sentry.client.config.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts`
+- Wrap `next.config.ts` with `withSentryConfig`
+- Add `app/global-error.tsx` error boundary
+- Tunnel via `/monitoring` route to avoid ad blockers
+
+**Structured logging — Pino:**
+- Install `pino`
+- Create `lib/logger.ts` with child loggers: `aiLogger`, `authLogger`, `dbLogger`
+- Replace all `console.error`/`console.log` in `app/actions/ai.ts` and `app/actions/goals.ts`
+- Redact sensitive fields (tokens, passwords)
+
+**Health check endpoint:**
+- Create `app/api/health/route.ts`
+- Check: database connectivity (`SELECT 1`), AI config, auth config
+- Return status `ok`/`degraded` with commit SHA
+
+**Performance monitoring:**
+- Install `@vercel/analytics` + `@vercel/speed-insights`
+- Add `<Analytics />` + `<SpeedInsights />` to `app/layout.tsx`
+- Enable Sentry Performance (automatic with `@sentry/nextjs`)
+- Add slow query logging in `lib/db.ts` (warn on queries > 100ms via Prisma `$on('query')`)
+
+**Dashboards (no custom infrastructure needed):**
+
+| Dashboard | What it covers |
+|-----------|---------------|
+| Vercel Dashboard | Deployments, function execution, bandwidth |
+| Vercel Analytics | Web Vitals (LCP, FID, CLS), page performance |
+| Sentry Dashboard | Error trends, release health, performance traces |
+| Neon Dashboard | DB size, connections, query performance |
+
+**Alerting:**
+- Sentry: alert on new errors, error rate > 10/min, P95 latency > 2s → Slack/email
+- Better Uptime (free tier): ping `/api/health` every 3 min, alert on downtime — external to Vercel so catches platform outages too
+
+### Phase 1D: Security Hardening
+
+**Security headers in `next.config.ts`:**
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+- `Strict-Transport-Security` (HSTS)
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy` (deny camera, microphone, geolocation)
+- `Content-Security-Policy` (self + Google avatar images + Gemini API + Vercel analytics)
+
+**Input validation — Zod:**
+- Install `zod`
+- Create `lib/validations.ts` with schemas for all server action inputs
+- Add `schema.parse(rawData)` at the top of each server action
+
+**Rate limiting — Upstash:**
+- Install `@upstash/ratelimit` + `@upstash/redis`
+- Add sliding window rate limit (100 req/min per IP) in `middleware.ts`
+
+---
+
+## Pillar 2: AI-Powered Task Breakdowns
+
+### Phase 2A: Smarter Milestone Generation
+
+**Current state:** `generateMilestones()` in `app/actions/ai.ts` produces 3-5 milestones with title + estimatedDays.
+
+**Improvements:**
+
+1. **Sub-task generation** — After creating milestones, offer to break each milestone into daily/weekly tasks
+   - New action: `generateTasksForMilestone(milestoneId)`
+   - Prompt includes milestone context, parent goal, user profile
+   - Returns 3-7 actionable tasks per milestone with suggested due dates
+   - UI: "Break down" button on each milestone in goal detail page
+
+2. **Adaptive difficulty** — Use user profile (skills, experience, completed goals) to calibrate milestone complexity
+   - Beginner users: more granular steps, shorter time estimates
+   - Experienced users: higher-level milestones, longer sprints
+   - Already partially supported via profile context in prompts — make it explicit
+
+3. **Iterative refinement** — Let users refine AI suggestions
+   - "Too broad" / "Too detailed" feedback buttons on milestone preview
+   - Re-generate with adjusted granularity prompt parameter
+   - New UI component: `MilestoneRefinementControls`
+
+4. **Template library** — Cache common goal patterns
+   - When AI generates milestones for popular goal types (fitness, learning, career), store anonymized templates
+   - Offer "Start from template" as instant alternative to AI generation
+   - New model: `MilestoneTemplate` with category, milestones JSON, usage count
+
+### Phase 2B: Intelligent Task Board Enhancements
+
+1. **Daily task plan generation** — AI generates a prioritized daily plan considering:
+   - Upcoming milestone deadlines
+   - Task dependencies (inferred from milestone order)
+   - User's historical completion patterns
+   - New action: `generateDailyPlan()` → returns ordered task list with time blocks
+
+2. **Smart rescheduling** — When a task is overdue or skipped:
+   - AI suggests how to redistribute remaining work
+   - Adjusts downstream milestone dates
+   - "Reschedule for me" button on overdue tasks
+
+3. **Weekly AI review** — Uses the existing `getProModel()` (gemini-1.5-pro, currently unused)
+   - Summarize week's accomplishments
+   - Identify at-risk goals
+   - Suggest focus areas for next week
+   - New page: `app/dashboard/insights/page.tsx`
+
+---
+
+## Pillar 3: Complementary Features (Suggestions)
+
+### Phase 3A: Data Export
+
+- Export goals/milestones/tasks as CSV or JSON
+- New action: `exportUserData(format: 'csv' | 'json')`
+- Settings page: "Export my data" button
+- Addresses FAQ item in User Guide
+
+### Phase 3B: Goal Analytics Dashboard
+
+- Visual progress charts (completion rate over time)
+- Category breakdown pie chart
+- Streak tracking (consecutive days with task completions)
+- New page: `app/dashboard/analytics/page.tsx`
+- Library: `recharts` (lightweight, React-native)
+
+### Phase 3C: Notification System
+
+- Email reminders for upcoming milestone deadlines
+- Browser push notifications for daily task plans
+- Configurable in settings (frequency, channels)
+- Library: `@vercel/functions` for scheduled cron + Resend for email
+
+---
+
+## Implementation Priority
+
+| Priority | Phase | What | New Packages |
+|----------|-------|------|-------------|
+| 1 | 1A | Testing foundation (Vitest + helpers + first tests) | vitest, @vitest/coverage-v8, @testing-library/*, jsdom |
+| 2 | 1B | CI/CD (GitHub Actions + pre-commit hooks) | husky, lint-staged |
+| 3 | 1A cont. | Reach 95% coverage across all actions + components | — |
+| 4 | 1C | Monitoring (Sentry + Pino + health check + Vercel Analytics) | @sentry/nextjs, pino, @vercel/analytics, @vercel/speed-insights |
+| 5 | 1D | Security (headers + Zod validation + rate limiting) | zod, @upstash/ratelimit, @upstash/redis |
+| 6 | 2A | AI milestone → task breakdown + refinement | — |
+| 7 | 2B | Daily plan generation + weekly AI review | — |
+| 8 | 3A | Data export | — |
+| 9 | 3B | Analytics dashboard | recharts |
+| 10 | 3C | Notifications | resend |
+
+---
+
+## Files to Create (by phase)
+
+### Phase 1A
+| File | Purpose |
+|------|---------|
+| `vitest.config.ts` | Vitest configuration with coverage thresholds |
+| `vitest.workspace.ts` | Unit + integration project workspaces |
+| `tests/setup.ts` | RTL cleanup + jest-dom matchers |
+| `tests/helpers/mock-auth.ts` | Shared auth mock |
+| `tests/helpers/mock-db.ts` | Prisma client mock factory |
+| `tests/helpers/mock-ai.ts` | Gemini model mock |
+| `tests/helpers/render-with-providers.tsx` | Custom render wrapper |
+| `tests/unit/` | Unit test files |
+| `tests/components/` | Component test files |
+| `tests/integration/` | Integration test files |
+| `tests/e2e/smoke.test.ts` | Production smoke test |
+
+### Phase 1B
+| File | Purpose |
+|------|---------|
+| `.husky/pre-commit` | Lint-staged pre-commit hook |
+| `.husky/pre-push` | Typecheck pre-push hook |
+| `.github/workflows/ci.yml` | CI/CD pipeline |
+
+### Phase 1C
+| File | Purpose |
+|------|---------|
+| `sentry.client.config.ts` | Sentry client config |
+| `sentry.server.config.ts` | Sentry server config |
+| `sentry.edge.config.ts` | Sentry edge config |
+| `app/global-error.tsx` | Error boundary |
+| `lib/logger.ts` | Pino structured logging |
+| `app/api/health/route.ts` | Health check endpoint |
+
+### Phase 1D
+| File | Purpose |
+|------|---------|
+| `lib/validations.ts` | Zod schemas for all inputs |
+
+### Phase 2A
+| File | Purpose |
+|------|---------|
+| `components/ai/milestone-refinement-controls.tsx` | Refinement UI |
+
+### Phase 2B
+| File | Purpose |
+|------|---------|
+| `app/dashboard/insights/page.tsx` | Weekly AI review page |
+
+### Phase 3A–3C
+| File | Purpose |
+|------|---------|
+| `app/dashboard/analytics/page.tsx` | Analytics dashboard |

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,17 +37,38 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.10.7",
         "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
+        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/ui": "^4.0.18",
         "dotenv": "^16.4.7",
         "eslint": "^9.18.0",
         "eslint-config-next": "^16.1.3",
+        "jsdom": "^27.4.0",
         "postcss": "^8.5.1",
         "prisma": "^6.3.0",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -60,6 +81,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@auth/core": {
       "version": "0.41.1",
@@ -271,7 +347,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -281,7 +357,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -315,7 +391,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
       "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.6"
@@ -325,6 +401,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -365,7 +451,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
       "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -373,6 +459,148 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -459,6 +687,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -603,6 +1273,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.10.0.tgz",
+      "integrity": "sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1426,6 +2114,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@prisma/client": {
       "version": "6.19.2",
@@ -3113,6 +3808,356 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.0.tgz",
+      "integrity": "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.0.tgz",
+      "integrity": "sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.0.tgz",
+      "integrity": "sha512-/NNIj9A7yLjKdmkx5dC2XQ9DmjIECpGpwHoGmA5E1AhU0fuICSqSWScPhN1yLCkEdkCwJIDu2xIeLPs60MNIVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.0.tgz",
+      "integrity": "sha512-xoh8abqgPrPYPr7pTYipqnUi1V3em56JzE/HgDgitTqZBZ3yKCWI+7KUkceM6tNweyUKYru1UMi7FC060RyKwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.0.tgz",
+      "integrity": "sha512-PCkMh7fNahWSbA0OTUQ2OpYHpjZZr0hPr8lId8twD7a7SeWrvT3xJVyza+dQwXSSq4yEQTMoXgNOfMCsn8584g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.0.tgz",
+      "integrity": "sha512-1j3stGx+qbhXql4OCDZhnK7b01s6rBKNybfsX+TNrEe9JNq4DLi1yGiR1xW+nL+FNVvI4D02PUnl6gJ/2y6WJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.0.tgz",
+      "integrity": "sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.0.tgz",
+      "integrity": "sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.0.tgz",
+      "integrity": "sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.0.tgz",
+      "integrity": "sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.0.tgz",
+      "integrity": "sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.0.tgz",
+      "integrity": "sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.0.tgz",
+      "integrity": "sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.0.tgz",
+      "integrity": "sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.0.tgz",
+      "integrity": "sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.0.tgz",
+      "integrity": "sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.0.tgz",
+      "integrity": "sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.0.tgz",
+      "integrity": "sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.0.tgz",
+      "integrity": "sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.0.tgz",
+      "integrity": "sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.0.tgz",
+      "integrity": "sha512-v5xwKDWcu7qhAEcsUubiav7r+48Uk/ENWdr82MBZZRIm7zThSxCIVDfb3ZeRRq9yqk+oIzMdDo6fCcA5DHfMyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.0.tgz",
+      "integrity": "sha512-XnaaaSMGSI6Wk8F4KK3QP7GfuuhjGchElsVerCplUuxRIzdvZ7hRBpLR0omCmw+kI2RFJB80nenhOoGXlJ5TfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.0.tgz",
+      "integrity": "sha512-3K1lP+3BXY4t4VihLw5MEg6IZD3ojSYzqzBG571W3kNQe4G4CcFpSUQVgurYgib5d+YaCjeFow8QivWp8vuSvA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.0.tgz",
+      "integrity": "sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.0.tgz",
+      "integrity": "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3136,6 +4181,107 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3146,6 +4292,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3723,6 +4895,182 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
+      "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.18"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3746,6 +5094,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3761,6 +5119,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -3993,10 +5362,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4060,6 +5458,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -4249,6 +5657,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4394,6 +5812,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4404,6 +5843,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -4419,6 +5884,30 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4492,6 +5981,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4552,6 +6048,17 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -4599,6 +6106,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4661,6 +6176,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4780,6 +6308,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4838,6 +6373,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
       }
     },
     "node_modules/escalade": {
@@ -5297,6 +6874,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5305,6 +6892,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -5396,6 +6993,13 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5812,6 +7416,54 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5847,6 +7499,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -6129,6 +7791,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6288,6 +7957,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6343,6 +8051,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -6525,6 +8273,43 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6534,6 +8319,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6557,6 +8349,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6578,6 +8380,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -6969,6 +8781,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -7055,6 +8878,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -7340,6 +9176,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prisma": {
       "version": "6.19.2",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
@@ -7556,6 +9430,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7598,6 +9486,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -7648,6 +9546,51 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
+      "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.0",
+        "@rollup/rollup-android-arm64": "4.57.0",
+        "@rollup/rollup-darwin-arm64": "4.57.0",
+        "@rollup/rollup-darwin-x64": "4.57.0",
+        "@rollup/rollup-freebsd-arm64": "4.57.0",
+        "@rollup/rollup-freebsd-x64": "4.57.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.0",
+        "@rollup/rollup-linux-arm64-musl": "4.57.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.0",
+        "@rollup/rollup-linux-loong64-musl": "4.57.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.0",
+        "@rollup/rollup-linux-x64-gnu": "4.57.0",
+        "@rollup/rollup-linux-x64-musl": "4.57.0",
+        "@rollup/rollup-openbsd-x64": "4.57.0",
+        "@rollup/rollup-openharmony-arm64": "4.57.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.0",
+        "@rollup/rollup-win32-x64-gnu": "4.57.0",
+        "@rollup/rollup-win32-x64-msvc": "4.57.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -7726,6 +9669,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7940,6 +9896,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7953,6 +9931,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8093,6 +10085,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8175,6 +10180,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
@@ -8338,6 +10350,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -8393,6 +10412,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8403,6 +10452,42 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8732,6 +10817,250 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8837,6 +11166,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8846,6 +11192,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "test": "vitest run --project unit",
+    "test:watch": "vitest --project unit",
+    "test:coverage": "vitest run --project unit --coverage",
+    "test:integration": "vitest run --project integration",
+    "test:smoke": "vitest run tests/e2e/smoke.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",
@@ -42,15 +48,22 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.10.7",
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",
+    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/ui": "^4.0.18",
     "dotenv": "^16.4.7",
     "eslint": "^9.18.0",
     "eslint-config-next": "^16.1.3",
+    "jsdom": "^27.4.0",
     "postcss": "^8.5.1",
     "prisma": "^6.3.0",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/tests/components/ai-suggest-button.test.tsx
+++ b/tests/components/ai-suggest-button.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AISuggestButton } from "@/components/ai/ai-suggest-button";
+
+describe("AISuggestButton", () => {
+  it("renders with default text", () => {
+    render(<AISuggestButton onClick={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /ai suggest/i })).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    render(<AISuggestButton onClick={vi.fn()} loading />);
+
+    expect(screen.getByRole("button", { name: /generating/i })).toBeDisabled();
+  });
+
+  it("calls onClick when clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<AISuggestButton onClick={onClick} />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    render(<AISuggestButton onClick={vi.fn()} disabled />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("is disabled when loading", () => {
+    render(<AISuggestButton onClick={vi.fn()} loading />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/tests/components/create-task-input.test.tsx
+++ b/tests/components/create-task-input.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CreateTaskInput } from "@/components/taskboard/create-task-input";
+
+// Mock the server action
+vi.mock("@/app/actions/tasks", () => ({
+  createTask: vi.fn().mockResolvedValue({ success: true, task: { id: "t-1" } }),
+}));
+
+describe("CreateTaskInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders input and submit button", () => {
+    render(<CreateTaskInput />);
+
+    expect(screen.getByPlaceholderText(/add a quick task/i)).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("submit button is disabled when input is empty", () => {
+    render(<CreateTaskInput />);
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("enables submit button when text is entered", async () => {
+    const user = userEvent.setup();
+    render(<CreateTaskInput />);
+
+    await user.type(screen.getByPlaceholderText(/add a quick task/i), "Buy groceries");
+
+    expect(screen.getByRole("button")).not.toBeDisabled();
+  });
+
+  it("calls createTask on form submit", async () => {
+    const user = userEvent.setup();
+    const { createTask } = await import("@/app/actions/tasks");
+    render(<CreateTaskInput />);
+
+    await user.type(screen.getByPlaceholderText(/add a quick task/i), "Buy groceries");
+    await user.click(screen.getByRole("button"));
+
+    expect(createTask).toHaveBeenCalledWith({ title: "Buy groceries" });
+  });
+
+  it("shows error message on failure", async () => {
+    const { createTask } = await import("@/app/actions/tasks");
+    (createTask as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      success: false,
+      error: "Daily limit reached",
+    });
+
+    const user = userEvent.setup();
+    render(<CreateTaskInput />);
+
+    await user.type(screen.getByPlaceholderText(/add a quick task/i), "Task");
+    await user.click(screen.getByRole("button"));
+
+    expect(await screen.findByText("Daily limit reached")).toBeInTheDocument();
+  });
+});

--- a/tests/components/delete-account-dialog.test.tsx
+++ b/tests/components/delete-account-dialog.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DeleteAccountDialog } from "@/components/settings/delete-account-dialog";
+
+// Mock server action
+vi.mock("@/app/actions/account", () => ({
+  deleteAccount: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+describe("DeleteAccountDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders danger zone card", () => {
+    render(<DeleteAccountDialog />);
+
+    expect(screen.getByText("Danger Zone")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete account/i })).toBeInTheDocument();
+  });
+
+  it("opens confirmation dialog when delete button clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeleteAccountDialog />);
+
+    await user.click(screen.getByRole("button", { name: /delete account/i }));
+
+    expect(screen.getByText(/permanent/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/type 'delete' to confirm/i)).toBeInTheDocument();
+  });
+
+  it("delete action button is disabled until 'delete' is typed", async () => {
+    const user = userEvent.setup();
+    render(<DeleteAccountDialog />);
+
+    await user.click(screen.getByRole("button", { name: /delete account/i }));
+
+    // The action button inside the dialog
+    const actionButtons = screen.getAllByRole("button", { name: /delete account/i });
+    const confirmButton = actionButtons[actionButtons.length - 1];
+    expect(confirmButton).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText(/type 'delete' to confirm/i), "delete");
+
+    expect(confirmButton).not.toBeDisabled();
+  });
+});

--- a/tests/components/goal-card.test.tsx
+++ b/tests/components/goal-card.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GoalCard } from "@/components/dashboard/goal-card";
+
+// Mock next/link
+import { vi } from "vitest";
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const baseGoal = {
+  id: "goal-1",
+  title: "Learn Rust",
+  description: "Master systems programming",
+  status: "IN_PROGRESS" as const,
+  priority: "HIGH" as const,
+  targetDate: new Date("2025-12-31"),
+  milestones: [
+    { id: "ms-1", title: "Basics", status: "COMPLETED" as const, dueDate: null, completedAt: new Date(), notes: null, goalId: "goal-1", createdAt: new Date(), updatedAt: new Date() },
+    { id: "ms-2", title: "Advanced", status: "PENDING" as const, dueDate: null, completedAt: null, notes: null, goalId: "goal-1", createdAt: new Date(), updatedAt: new Date() },
+  ],
+};
+
+describe("GoalCard", () => {
+  it("renders goal title", () => {
+    render(<GoalCard goal={baseGoal} />);
+
+    expect(screen.getByText("Learn Rust")).toBeInTheDocument();
+  });
+
+  it("renders goal description", () => {
+    render(<GoalCard goal={baseGoal} />);
+
+    expect(screen.getByText("Master systems programming")).toBeInTheDocument();
+  });
+
+  it("renders status badge", () => {
+    render(<GoalCard goal={baseGoal} />);
+
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+  });
+
+  it("renders milestone progress", () => {
+    render(<GoalCard goal={baseGoal} />);
+
+    expect(screen.getByText("1/2 milestones")).toBeInTheDocument();
+  });
+
+  it("links to goal detail page", () => {
+    render(<GoalCard goal={baseGoal} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/dashboard/goals/goal-1");
+  });
+
+  it("handles goal with no milestones", () => {
+    render(<GoalCard goal={{ ...baseGoal, milestones: [] }} />);
+
+    expect(screen.queryByText(/milestones/)).not.toBeInTheDocument();
+  });
+
+  it("handles goal with no description", () => {
+    render(<GoalCard goal={{ ...baseGoal, description: null }} />);
+
+    expect(screen.queryByText("Master systems programming")).not.toBeInTheDocument();
+  });
+});

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+
+const PRODUCTION_URL = process.env.PRODUCTION_URL || "https://questive.vercel.app";
+
+describe("Production smoke tests", () => {
+  it("landing page returns 200", async () => {
+    const res = await fetch(PRODUCTION_URL);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns HTML content", async () => {
+    const res = await fetch(PRODUCTION_URL);
+    const contentType = res.headers.get("content-type");
+    expect(contentType).toContain("text/html");
+  });
+
+  it("health check endpoint responds (when available)", async () => {
+    const res = await fetch(`${PRODUCTION_URL}/api/health`);
+    // Health endpoint may not exist yet — 200 or 404 are both acceptable
+    // during incremental rollout. Once Phase 1C is done, tighten to 200.
+    expect([200, 404]).toContain(res.status);
+  });
+
+  it("dashboard redirects unauthenticated users", async () => {
+    const res = await fetch(`${PRODUCTION_URL}/dashboard`, {
+      redirect: "manual",
+    });
+    // Should redirect (302/307) to login
+    expect([200, 302, 307]).toContain(res.status);
+  });
+});

--- a/tests/helpers/mock-ai.ts
+++ b/tests/helpers/mock-ai.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest";
+
+export const mockGenerateContent = vi.fn();
+
+const mockModel = {
+  generateContent: mockGenerateContent,
+};
+
+/**
+ * Mock `@/lib/ai/gemini` with a controllable model.
+ *
+ * Use `mockGenerateContent.mockResolvedValue(...)` in individual tests
+ * to control AI responses.
+ */
+export function mockAI(available = true) {
+  vi.mock("@/lib/ai/gemini", () => ({
+    getFlashModel: vi.fn(() => mockModel),
+    getProModel: vi.fn(() => mockModel),
+    isAIAvailable: vi.fn(() => available),
+  }));
+}
+
+/**
+ * Helper: create a mock AI response matching the Gemini SDK shape.
+ */
+export function aiResponse(json: Record<string, unknown>) {
+  return {
+    response: {
+      text: () => JSON.stringify(json),
+    },
+  };
+}

--- a/tests/helpers/mock-auth.ts
+++ b/tests/helpers/mock-auth.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+
+export interface MockSession {
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    image: string | null;
+  };
+  expires: string;
+}
+
+export const DEFAULT_SESSION: MockSession = {
+  user: {
+    id: "user-1",
+    name: "Test User",
+    email: "test@example.com",
+    image: null,
+  },
+  expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+};
+
+/**
+ * The mock auth function.
+ * Set `mockAuthFn.mockResolvedValue(session)` to change the session.
+ */
+export const mockAuthFn = vi.fn().mockResolvedValue(DEFAULT_SESSION);
+export const mockSignIn = vi.fn();
+export const mockSignOut = vi.fn();

--- a/tests/helpers/mock-db.ts
+++ b/tests/helpers/mock-db.ts
@@ -1,0 +1,62 @@
+import { vi } from "vitest";
+
+// Factory to create a mock Prisma model with common methods
+function createModelMock() {
+  return {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  };
+}
+
+export const mockPrisma = {
+  user: createModelMock(),
+  userProfile: createModelMock(),
+  category: createModelMock(),
+  goal: createModelMock(),
+  milestone: createModelMock(),
+  task: createModelMock(),
+  account: createModelMock(),
+  session: createModelMock(),
+  $transaction: vi.fn(async (args: unknown) => {
+    // Support both callback and array forms
+    if (typeof args === "function") {
+      return args(mockPrisma);
+    }
+    // Array of promises
+    return Promise.all(args as Promise<unknown>[]);
+  }),
+};
+
+export function mockDb() {
+  vi.mock("@/lib/db", () => ({
+    db: mockPrisma,
+  }));
+}
+
+/**
+ * Reset all mock implementations and return values.
+ * Call in `beforeEach` to get a clean slate.
+ */
+export function resetDbMocks() {
+  for (const model of Object.values(mockPrisma)) {
+    if (typeof model === "object" && model !== null) {
+      for (const method of Object.values(model)) {
+        if (typeof method === "function" && "mockReset" in method) {
+          (method as ReturnType<typeof vi.fn>).mockReset();
+        }
+      }
+    }
+  }
+  // Re-apply default for $transaction
+  mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+    if (typeof args === "function") return args(mockPrisma);
+    return Promise.all(args as Promise<unknown>[]);
+  });
+}

--- a/tests/helpers/render-with-providers.tsx
+++ b/tests/helpers/render-with-providers.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from "react";
+import { render, RenderOptions } from "@testing-library/react";
+import { SessionProvider } from "@/components/providers/session-provider";
+import { ThemeProvider } from "@/components/providers/theme-provider";
+
+function AllProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
+    </SessionProvider>
+  );
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper">
+) {
+  return render(ui, { wrapper: AllProviders, ...options });
+}

--- a/tests/integration/goal-lifecycle.test.ts
+++ b/tests/integration/goal-lifecycle.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Integration tests that exercise multi-step flows with a mock DB.
+ *
+ * When Phase 1A matures, these will use a real PostgreSQL via Docker.
+ * For now they validate the logical flow across action boundaries
+ * using the same mock infrastructure as unit tests.
+ */
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Mock AI module (used by goals via updateProfileFromCompletion)
+vi.mock("@/app/actions/ai", () => ({
+  updateProfileFromCompletion: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// Import code under test
+import { createCategory, getCategories } from "@/app/actions/categories";
+import { createGoal, updateGoal, getDashboardStats } from "@/app/actions/goals";
+import { createMilestone, toggleMilestoneStatus } from "@/app/actions/milestones";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("Goal lifecycle integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  it("create category → goal → milestone → complete flow", async () => {
+    // Step 1: Create category
+    const category = { id: "cat-1", name: "Learning", userId: "user-1" };
+    mockPrisma.category.create.mockResolvedValue(category);
+
+    const createdCat = await createCategory({ name: "Learning" });
+    expect(createdCat.name).toBe("Learning");
+
+    // Step 2: Create goal in category
+    mockPrisma.category.findFirst.mockResolvedValue(category);
+    const goal = { id: "goal-1", title: "Learn TypeScript", categoryId: "cat-1", status: "NOT_STARTED" };
+    mockPrisma.goal.create.mockResolvedValue(goal);
+
+    const createdGoal = await createGoal({
+      title: "Learn TypeScript",
+      categoryId: "cat-1",
+    });
+    expect(createdGoal.title).toBe("Learn TypeScript");
+
+    // Step 3: Create milestone
+    mockPrisma.goal.findFirst.mockResolvedValue({ id: "goal-1", userId: "user-1" });
+    const milestone = { id: "ms-1", title: "Basics", status: "PENDING", goalId: "goal-1" };
+    mockPrisma.milestone.create.mockResolvedValue(milestone);
+
+    const createdMs = await createMilestone({
+      title: "Basics",
+      goalId: "goal-1",
+    });
+    expect(createdMs.title).toBe("Basics");
+
+    // Step 4: Complete milestone
+    mockPrisma.milestone.findFirst.mockResolvedValue({
+      ...milestone,
+      goal: { userId: "user-1" },
+    });
+    mockPrisma.milestone.update.mockResolvedValue({
+      ...milestone,
+      status: "COMPLETED",
+    });
+
+    const toggled = await toggleMilestoneStatus("ms-1");
+    expect(toggled.status).toBe("COMPLETED");
+
+    // Step 5: Complete goal
+    mockPrisma.goal.findFirst.mockResolvedValue({
+      id: "goal-1",
+      userId: "user-1",
+      categoryId: "cat-1",
+      status: "IN_PROGRESS",
+    });
+    mockPrisma.goal.update.mockResolvedValue({
+      id: "goal-1",
+      status: "COMPLETED",
+    });
+
+    const completedGoal = await updateGoal("goal-1", { status: "COMPLETED" as const });
+    expect(completedGoal.status).toBe("COMPLETED");
+
+    // Step 6: Verify stats reflect completion
+    mockPrisma.goal.count
+      .mockResolvedValueOnce(1)  // total
+      .mockResolvedValueOnce(1)  // completed
+      .mockResolvedValueOnce(0); // in progress
+    mockPrisma.milestone.count
+      .mockResolvedValueOnce(1)  // total
+      .mockResolvedValueOnce(1); // completed
+
+    const stats = await getDashboardStats();
+    expect(stats.completionRate).toBe(100);
+    expect(stats.completedGoals).toBe(1);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Automatic cleanup after each test
+afterEach(() => {
+  cleanup();
+});

--- a/tests/unit/actions/account.test.ts
+++ b/tests/unit/actions/account.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Import code under test
+import { getProfile, deleteAccount } from "@/app/actions/account";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("account actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  describe("getProfile", () => {
+    it("returns user profile when authenticated", async () => {
+      const user = {
+        id: "user-1",
+        name: "Test User",
+        email: "test@example.com",
+        image: null,
+        createdAt: new Date(),
+      };
+      mockPrisma.user.findUnique.mockResolvedValue(user);
+
+      const result = await getProfile();
+
+      expect(result).toEqual(user);
+      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          image: true,
+          createdAt: true,
+        },
+      });
+    });
+
+    it("returns null when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await getProfile();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteAccount", () => {
+    it("deletes user and signs out", async () => {
+      mockPrisma.user.delete.mockResolvedValue({});
+
+      const result = await deleteAccount();
+
+      expect(result).toEqual({ success: true });
+      expect(mockPrisma.user.delete).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+      });
+    });
+
+    it("returns error when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await deleteAccount();
+
+      expect(result).toEqual({ success: false, error: "Unauthorized" });
+    });
+
+    it("returns error when deletion fails", async () => {
+      mockPrisma.user.delete.mockRejectedValue(new Error("DB error"));
+
+      const result = await deleteAccount();
+
+      expect(result).toEqual({ success: false, error: "Failed to delete account" });
+    });
+  });
+});

--- a/tests/unit/actions/ai.test.ts
+++ b/tests/unit/actions/ai.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma, mockGenerateContent } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockGenerateContent: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock("@/lib/ai/gemini", () => {
+  const mockModel = { generateContent: mockGenerateContent };
+  return {
+    getFlashModel: vi.fn(() => mockModel),
+    getProModel: vi.fn(() => mockModel),
+    isAIAvailable: vi.fn(() => true),
+  };
+});
+
+// Import code under test
+import {
+  generateMilestones,
+  prioritizeTasks,
+  updateProfileFromCompletion,
+  getAIStatus,
+} from "@/app/actions/ai";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+/** Helper: create a mock AI response matching the Gemini SDK shape. */
+function aiResponse(json: Record<string, unknown>) {
+  return {
+    response: {
+      text: () => JSON.stringify(json),
+    },
+  };
+}
+
+describe("AI actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  describe("generateMilestones", () => {
+    it("generates milestones for a goal", async () => {
+      // Rate limit check: no profile = allowed
+      mockPrisma.userProfile.findUnique.mockResolvedValue(null);
+
+      const milestones = [
+        { title: "Step 1", estimatedDays: 7, order: 1 },
+        { title: "Step 2", estimatedDays: 14, order: 2 },
+      ];
+      mockGenerateContent.mockResolvedValue(aiResponse({ milestones }));
+
+      const result = await generateMilestones("Learn TypeScript");
+
+      expect(result.success).toBe(true);
+      expect(result.milestones).toEqual(milestones);
+    });
+
+    it("returns error when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await generateMilestones("Test");
+
+      expect(result).toEqual({ success: false, error: "Unauthorized" });
+    });
+
+    it("returns error when rate limited", async () => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      mockPrisma.userProfile.findUnique.mockResolvedValue({
+        aiCallsToday: 10,
+        lastAICallDate: today,
+      });
+
+      const result = await generateMilestones("Test");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("limit");
+    });
+
+    it("returns error when AI generation fails", async () => {
+      mockPrisma.userProfile.findUnique.mockResolvedValue(null);
+      mockGenerateContent.mockRejectedValue(new Error("API error"));
+
+      const result = await generateMilestones("Test");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to generate");
+    });
+
+    it("increments call count on success", async () => {
+      mockPrisma.userProfile.findUnique.mockResolvedValue(null);
+      mockGenerateContent.mockResolvedValue(aiResponse({ milestones: [] }));
+
+      await generateMilestones("Test");
+
+      expect(mockPrisma.userProfile.upsert).toHaveBeenCalled();
+    });
+
+    it("includes profile context in prompt when profile exists", async () => {
+      mockPrisma.userProfile.findUnique
+        .mockResolvedValueOnce(null) // rate limit check
+        .mockResolvedValueOnce({
+          bio: "Software engineer",
+          currentRole: "Developer",
+          yearsExperience: 5,
+          company: "Acme",
+          skills: ["JavaScript"],
+          skillsGained: ["React"],
+        });
+      mockGenerateContent.mockResolvedValue(aiResponse({ milestones: [] }));
+
+      await generateMilestones("Learn Rust");
+
+      const prompt = mockGenerateContent.mock.calls[0][0];
+      expect(prompt).toContain("Software engineer");
+    });
+  });
+
+  describe("prioritizeTasks", () => {
+    it("prioritizes tasks and returns ordered IDs", async () => {
+      mockPrisma.userProfile.findUnique.mockResolvedValue(null);
+      mockGenerateContent.mockResolvedValue(
+        aiResponse({
+          orderedTaskIds: ["t-2", "t-1"],
+          reasoning: "Deadline first",
+        })
+      );
+
+      const tasks = [
+        { id: "t-1", title: "Task 1" },
+        { id: "t-2", title: "Task 2", dueDate: new Date() },
+      ];
+
+      const result = await prioritizeTasks(tasks);
+
+      expect(result.success).toBe(true);
+      expect(result.orderedTaskIds).toEqual(["t-2", "t-1"]);
+    });
+
+    it("rejects with fewer than 2 tasks", async () => {
+      const result = await prioritizeTasks([{ id: "t-1", title: "Only one" }]);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("at least 2");
+    });
+
+    it("returns error when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await prioritizeTasks([
+        { id: "t-1", title: "A" },
+        { id: "t-2", title: "B" },
+      ]);
+
+      expect(result).toEqual({ success: false, error: "Unauthorized" });
+    });
+  });
+
+  describe("updateProfileFromCompletion", () => {
+    it("extracts skills from completed goal", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue({
+        id: "goal-1",
+        title: "Learn React",
+        description: "Learn React fundamentals",
+        milestones: [{ title: "Components" }, { title: "Hooks" }],
+      });
+      mockGenerateContent.mockResolvedValue(
+        aiResponse({ skillsGained: ["React", "Hooks"] })
+      );
+      mockPrisma.userProfile.upsert.mockResolvedValue({});
+
+      const result = await updateProfileFromCompletion("goal-1");
+
+      expect(result.success).toBe(true);
+      expect(result.skillsGained).toEqual(["React", "Hooks"]);
+    });
+
+    it("returns success with empty skills when AI unavailable", async () => {
+      // Re-import with AI unavailable - this is already mocked as available.
+      // Instead, test the error catch path:
+      mockPrisma.goal.findFirst.mockResolvedValue({
+        id: "goal-1",
+        title: "Test",
+        milestones: [],
+      });
+      mockGenerateContent.mockRejectedValue(new Error("API down"));
+
+      const result = await updateProfileFromCompletion("goal-1");
+
+      // Background operation: returns success even on AI error
+      expect(result.success).toBe(true);
+      expect(result.skillsGained).toEqual([]);
+    });
+
+    it("returns error when goal not found", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue(null);
+
+      const result = await updateProfileFromCompletion("goal-999");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Goal not found");
+    });
+  });
+
+  describe("getAIStatus", () => {
+    it("returns available status with remaining calls", async () => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      mockPrisma.userProfile.findUnique.mockResolvedValue({
+        aiCallsToday: 3,
+        lastAICallDate: today,
+      });
+
+      const status = await getAIStatus();
+
+      expect(status.available).toBe(true);
+      expect(status.remainingCalls).toBe(7);
+    });
+
+    it("resets counter for new day", async () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      mockPrisma.userProfile.findUnique.mockResolvedValue({
+        aiCallsToday: 10,
+        lastAICallDate: yesterday,
+      });
+
+      const status = await getAIStatus();
+
+      expect(status.remainingCalls).toBe(10);
+    });
+
+    it("returns unavailable when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const status = await getAIStatus();
+
+      expect(status).toEqual({ available: false, remainingCalls: 0 });
+    });
+  });
+});

--- a/tests/unit/actions/categories.test.ts
+++ b/tests/unit/actions/categories.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Import code under test
+import {
+  getCategories,
+  getCategory,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from "@/app/actions/categories";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("category actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  describe("getCategories", () => {
+    it("returns all categories for the user", async () => {
+      const categories = [
+        { id: "cat-1", name: "Health", goals: [] },
+        { id: "cat-2", name: "Career", goals: [] },
+      ];
+      mockPrisma.category.findMany.mockResolvedValue(categories);
+
+      const result = await getCategories();
+
+      expect(result).toEqual(categories);
+      expect(mockPrisma.category.findMany).toHaveBeenCalledWith({
+        where: { userId: "user-1" },
+        include: { goals: { select: { id: true, status: true } } },
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(getCategories()).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("getCategory", () => {
+    it("returns a single category with goals and milestones", async () => {
+      const category = { id: "cat-1", name: "Health", goals: [] };
+      mockPrisma.category.findFirst.mockResolvedValue(category);
+
+      const result = await getCategory("cat-1");
+
+      expect(result).toEqual(category);
+      expect(mockPrisma.category.findFirst).toHaveBeenCalledWith({
+        where: { id: "cat-1", userId: "user-1" },
+        include: {
+          goals: {
+            include: { milestones: true },
+            orderBy: { createdAt: "desc" },
+          },
+        },
+      });
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(getCategory("cat-1")).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("createCategory", () => {
+    it("creates a category with defaults", async () => {
+      const category = {
+        id: "cat-1",
+        name: "Fitness",
+        color: "#3b82f6",
+        icon: "folder",
+        userId: "user-1",
+      };
+      mockPrisma.category.create.mockResolvedValue(category);
+
+      const result = await createCategory({ name: "Fitness" });
+
+      expect(result).toEqual(category);
+      expect(mockPrisma.category.create).toHaveBeenCalledWith({
+        data: {
+          name: "Fitness",
+          color: "#3b82f6",
+          icon: "folder",
+          userId: "user-1",
+        },
+      });
+    });
+
+    it("creates a category with custom color and icon", async () => {
+      mockPrisma.category.create.mockResolvedValue({});
+
+      await createCategory({ name: "Health", color: "#ff0000", icon: "heart" });
+
+      expect(mockPrisma.category.create).toHaveBeenCalledWith({
+        data: {
+          name: "Health",
+          color: "#ff0000",
+          icon: "heart",
+          userId: "user-1",
+        },
+      });
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(createCategory({ name: "Test" })).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("updateCategory", () => {
+    it("updates category when owner", async () => {
+      mockPrisma.category.findFirst.mockResolvedValue({ id: "cat-1", userId: "user-1" });
+      mockPrisma.category.update.mockResolvedValue({ id: "cat-1", name: "Updated" });
+
+      const result = await updateCategory("cat-1", { name: "Updated" });
+
+      expect(result).toEqual({ id: "cat-1", name: "Updated" });
+    });
+
+    it("throws when category not found (ownership check)", async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+
+      await expect(updateCategory("cat-999", { name: "Test" })).rejects.toThrow(
+        "Category not found"
+      );
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(updateCategory("cat-1", { name: "Test" })).rejects.toThrow(
+        "Unauthorized"
+      );
+    });
+  });
+
+  describe("deleteCategory", () => {
+    it("deletes category when owner", async () => {
+      mockPrisma.category.findFirst.mockResolvedValue({ id: "cat-1", userId: "user-1" });
+      mockPrisma.category.delete.mockResolvedValue({});
+
+      await deleteCategory("cat-1");
+
+      expect(mockPrisma.category.delete).toHaveBeenCalledWith({
+        where: { id: "cat-1" },
+      });
+    });
+
+    it("throws when category not found", async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+
+      await expect(deleteCategory("cat-999")).rejects.toThrow("Category not found");
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(deleteCategory("cat-1")).rejects.toThrow("Unauthorized");
+    });
+  });
+});

--- a/tests/unit/actions/goals.test.ts
+++ b/tests/unit/actions/goals.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Mock the AI import used by goals.ts
+vi.mock("@/app/actions/ai", () => ({
+  updateProfileFromCompletion: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+// Import code under test
+import {
+  getGoals,
+  getGoal,
+  createGoal,
+  updateGoal,
+  deleteGoal,
+  getDashboardStats,
+} from "@/app/actions/goals";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("goal actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  describe("getGoals", () => {
+    it("returns all goals for the user", async () => {
+      const goals = [{ id: "goal-1", title: "Learn Rust" }];
+      mockPrisma.goal.findMany.mockResolvedValue(goals);
+
+      const result = await getGoals();
+
+      expect(result).toEqual(goals);
+      expect(mockPrisma.goal.findMany).toHaveBeenCalledWith({
+        where: { userId: "user-1" },
+        include: { category: true, milestones: true },
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("filters by categoryId when provided", async () => {
+      mockPrisma.goal.findMany.mockResolvedValue([]);
+
+      await getGoals("cat-1");
+
+      expect(mockPrisma.goal.findMany).toHaveBeenCalledWith({
+        where: { userId: "user-1", categoryId: "cat-1" },
+        include: { category: true, milestones: true },
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(getGoals()).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("getGoal", () => {
+    it("returns a goal with category and milestones", async () => {
+      const goal = { id: "goal-1", title: "Learn Rust", milestones: [] };
+      mockPrisma.goal.findFirst.mockResolvedValue(goal);
+
+      const result = await getGoal("goal-1");
+
+      expect(result).toEqual(goal);
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(getGoal("goal-1")).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("createGoal", () => {
+    it("creates a goal after verifying category ownership", async () => {
+      mockPrisma.category.findFirst.mockResolvedValue({ id: "cat-1", userId: "user-1" });
+      const goal = { id: "goal-1", title: "Learn Rust" };
+      mockPrisma.goal.create.mockResolvedValue(goal);
+
+      const result = await createGoal({
+        title: "Learn Rust",
+        categoryId: "cat-1",
+      });
+
+      expect(result).toEqual(goal);
+      expect(mockPrisma.goal.create).toHaveBeenCalledWith({
+        data: {
+          title: "Learn Rust",
+          description: undefined,
+          priority: "MEDIUM",
+          targetDate: undefined,
+          categoryId: "cat-1",
+          userId: "user-1",
+        },
+      });
+    });
+
+    it("throws when category not owned by user", async () => {
+      mockPrisma.category.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createGoal({ title: "Test", categoryId: "cat-999" })
+      ).rejects.toThrow("Category not found");
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(
+        createGoal({ title: "Test", categoryId: "cat-1" })
+      ).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("updateGoal", () => {
+    it("updates goal when owner", async () => {
+      const goal = { id: "goal-1", userId: "user-1", categoryId: "cat-1", status: "IN_PROGRESS" };
+      mockPrisma.goal.findFirst.mockResolvedValue(goal);
+      mockPrisma.goal.update.mockResolvedValue({ ...goal, title: "Updated" });
+
+      const result = await updateGoal("goal-1", { title: "Updated" });
+
+      expect(result.title).toBe("Updated");
+    });
+
+    it("verifies new category ownership when changing category", async () => {
+      const goal = { id: "goal-1", userId: "user-1", categoryId: "cat-1", status: "NOT_STARTED" };
+      mockPrisma.goal.findFirst.mockResolvedValueOnce(goal); // goal lookup
+      mockPrisma.category.findFirst.mockResolvedValue(null); // new category not found
+
+      await expect(
+        updateGoal("goal-1", { categoryId: "cat-999" })
+      ).rejects.toThrow("Category not found");
+    });
+
+    it("triggers profile update when goal is completed", async () => {
+      const { updateProfileFromCompletion } = await import("@/app/actions/ai");
+      const goal = { id: "goal-1", userId: "user-1", categoryId: "cat-1", status: "IN_PROGRESS" };
+      mockPrisma.goal.findFirst.mockResolvedValue(goal);
+      mockPrisma.goal.update.mockResolvedValue({ ...goal, status: "COMPLETED" });
+
+      await updateGoal("goal-1", { status: "COMPLETED" as const });
+
+      expect(updateProfileFromCompletion).toHaveBeenCalledWith("goal-1");
+    });
+
+    it("throws when goal not found", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue(null);
+
+      await expect(updateGoal("goal-999", { title: "Test" })).rejects.toThrow(
+        "Goal not found"
+      );
+    });
+  });
+
+  describe("deleteGoal", () => {
+    it("deletes goal when owner", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue({
+        id: "goal-1",
+        userId: "user-1",
+        categoryId: "cat-1",
+      });
+      mockPrisma.goal.delete.mockResolvedValue({});
+
+      await deleteGoal("goal-1");
+
+      expect(mockPrisma.goal.delete).toHaveBeenCalledWith({
+        where: { id: "goal-1" },
+      });
+    });
+
+    it("throws when goal not found", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue(null);
+
+      await expect(deleteGoal("goal-999")).rejects.toThrow("Goal not found");
+    });
+  });
+
+  describe("getDashboardStats", () => {
+    it("returns aggregated stats", async () => {
+      mockPrisma.goal.count
+        .mockResolvedValueOnce(10) // totalGoals
+        .mockResolvedValueOnce(3) // completedGoals
+        .mockResolvedValueOnce(5); // inProgressGoals
+      mockPrisma.milestone.count
+        .mockResolvedValueOnce(20) // totalMilestones
+        .mockResolvedValueOnce(8); // completedMilestones
+
+      const stats = await getDashboardStats();
+
+      expect(stats).toEqual({
+        totalGoals: 10,
+        completedGoals: 3,
+        inProgressGoals: 5,
+        totalMilestones: 20,
+        completedMilestones: 8,
+        completionRate: 30,
+      });
+    });
+
+    it("returns 0 completion rate when no goals", async () => {
+      mockPrisma.goal.count.mockResolvedValue(0);
+      mockPrisma.milestone.count.mockResolvedValue(0);
+
+      const stats = await getDashboardStats();
+
+      expect(stats.completionRate).toBe(0);
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(getDashboardStats()).rejects.toThrow("Unauthorized");
+    });
+  });
+});

--- a/tests/unit/actions/milestones.test.ts
+++ b/tests/unit/actions/milestones.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Import code under test
+import {
+  getMilestones,
+  createMilestone,
+  updateMilestone,
+  toggleMilestoneStatus,
+  deleteMilestone,
+  getUpcomingMilestones,
+} from "@/app/actions/milestones";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("milestone actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  describe("getMilestones", () => {
+    it("returns milestones after verifying goal ownership", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue({ id: "goal-1", userId: "user-1" });
+      const milestones = [{ id: "ms-1", title: "Step 1" }];
+      mockPrisma.milestone.findMany.mockResolvedValue(milestones);
+
+      const result = await getMilestones("goal-1");
+
+      expect(result).toEqual(milestones);
+    });
+
+    it("throws when goal not owned by user", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue(null);
+
+      await expect(getMilestones("goal-999")).rejects.toThrow("Goal not found");
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(getMilestones("goal-1")).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("createMilestone", () => {
+    it("creates milestone after verifying goal ownership", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue({ id: "goal-1", userId: "user-1" });
+      const milestone = { id: "ms-1", title: "Step 1", goalId: "goal-1" };
+      mockPrisma.milestone.create.mockResolvedValue(milestone);
+
+      const result = await createMilestone({ title: "Step 1", goalId: "goal-1" });
+
+      expect(result).toEqual(milestone);
+    });
+
+    it("throws when goal not found", async () => {
+      mockPrisma.goal.findFirst.mockResolvedValue(null);
+
+      await expect(
+        createMilestone({ title: "Test", goalId: "goal-999" })
+      ).rejects.toThrow("Goal not found");
+    });
+  });
+
+  describe("updateMilestone", () => {
+    it("updates milestone when owner", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue({
+        id: "ms-1",
+        goal: { userId: "user-1" },
+        goalId: "goal-1",
+      });
+      mockPrisma.milestone.update.mockResolvedValue({ id: "ms-1", title: "Updated" });
+
+      const result = await updateMilestone("ms-1", { title: "Updated" });
+
+      expect(result.title).toBe("Updated");
+    });
+
+    it("throws when milestone not found or not owned", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue(null);
+
+      await expect(updateMilestone("ms-999", { title: "Test" })).rejects.toThrow(
+        "Milestone not found"
+      );
+    });
+
+    it("throws when milestone belongs to another user", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue({
+        id: "ms-1",
+        goal: { userId: "other-user" },
+      });
+
+      await expect(updateMilestone("ms-1", { title: "Test" })).rejects.toThrow(
+        "Milestone not found"
+      );
+    });
+  });
+
+  describe("toggleMilestoneStatus", () => {
+    it("toggles PENDING to COMPLETED", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue({
+        id: "ms-1",
+        status: "PENDING",
+        goal: { userId: "user-1" },
+        goalId: "goal-1",
+      });
+      mockPrisma.milestone.update.mockResolvedValue({
+        id: "ms-1",
+        status: "COMPLETED",
+      });
+
+      const result = await toggleMilestoneStatus("ms-1");
+
+      expect(result.status).toBe("COMPLETED");
+      expect(mockPrisma.milestone.update).toHaveBeenCalledWith({
+        where: { id: "ms-1" },
+        data: {
+          status: "COMPLETED",
+          completedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it("toggles COMPLETED to PENDING", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue({
+        id: "ms-1",
+        status: "COMPLETED",
+        goal: { userId: "user-1" },
+        goalId: "goal-1",
+      });
+      mockPrisma.milestone.update.mockResolvedValue({
+        id: "ms-1",
+        status: "PENDING",
+      });
+
+      const result = await toggleMilestoneStatus("ms-1");
+
+      expect(result.status).toBe("PENDING");
+      expect(mockPrisma.milestone.update).toHaveBeenCalledWith({
+        where: { id: "ms-1" },
+        data: {
+          status: "PENDING",
+          completedAt: null,
+        },
+      });
+    });
+
+    it("throws when not found", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue(null);
+
+      await expect(toggleMilestoneStatus("ms-999")).rejects.toThrow(
+        "Milestone not found"
+      );
+    });
+  });
+
+  describe("deleteMilestone", () => {
+    it("deletes milestone when owner", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue({
+        id: "ms-1",
+        goal: { userId: "user-1" },
+        goalId: "goal-1",
+      });
+      mockPrisma.milestone.delete.mockResolvedValue({});
+
+      await deleteMilestone("ms-1");
+
+      expect(mockPrisma.milestone.delete).toHaveBeenCalledWith({
+        where: { id: "ms-1" },
+      });
+    });
+
+    it("throws when not found", async () => {
+      mockPrisma.milestone.findFirst.mockResolvedValue(null);
+
+      await expect(deleteMilestone("ms-999")).rejects.toThrow("Milestone not found");
+    });
+  });
+
+  describe("getUpcomingMilestones", () => {
+    it("returns pending milestones with future due dates", async () => {
+      const milestones = [
+        { id: "ms-1", title: "Step 1", goal: { id: "g-1", title: "Goal" } },
+      ];
+      mockPrisma.milestone.findMany.mockResolvedValue(milestones);
+
+      const result = await getUpcomingMilestones(5);
+
+      expect(result).toEqual(milestones);
+      expect(mockPrisma.milestone.findMany).toHaveBeenCalledWith({
+        where: {
+          goal: { userId: "user-1" },
+          status: "PENDING",
+          dueDate: { gte: expect.any(Date) },
+        },
+        include: {
+          goal: { select: { id: true, title: true } },
+        },
+        orderBy: { dueDate: "asc" },
+        take: 5,
+      });
+    });
+
+    it("throws when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      await expect(getUpcomingMilestones()).rejects.toThrow("Unauthorized");
+    });
+  });
+});

--- a/tests/unit/actions/profile.test.ts
+++ b/tests/unit/actions/profile.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Import code under test
+import {
+  getExtendedProfile,
+  createOrUpdateProfile,
+  getSkillsGained,
+} from "@/app/actions/profile";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("profile actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  describe("getExtendedProfile", () => {
+    it("returns profile when authenticated", async () => {
+      const profile = {
+        id: "prof-1",
+        userId: "user-1",
+        currentRole: "Developer",
+        skills: ["TypeScript"],
+        skillsGained: [],
+        completedGoalsCount: 0,
+      };
+      mockPrisma.userProfile.findUnique.mockResolvedValue(profile);
+
+      const result = await getExtendedProfile();
+
+      expect(result).toEqual(profile);
+    });
+
+    it("returns null when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await getExtendedProfile();
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when profile does not exist", async () => {
+      mockPrisma.userProfile.findUnique.mockResolvedValue(null);
+
+      const result = await getExtendedProfile();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createOrUpdateProfile", () => {
+    it("upserts profile data", async () => {
+      mockPrisma.userProfile.upsert.mockResolvedValue({});
+
+      const result = await createOrUpdateProfile({
+        currentRole: "Engineer",
+        yearsExperience: 5,
+        company: "Acme",
+        skills: ["TypeScript", "React"],
+        bio: "Full-stack dev",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockPrisma.userProfile.upsert).toHaveBeenCalledWith({
+        where: { userId: "user-1" },
+        create: {
+          userId: "user-1",
+          currentRole: "Engineer",
+          yearsExperience: 5,
+          company: "Acme",
+          skills: ["TypeScript", "React"],
+          bio: "Full-stack dev",
+        },
+        update: {
+          currentRole: "Engineer",
+          yearsExperience: 5,
+          company: "Acme",
+          skills: ["TypeScript", "React"],
+          bio: "Full-stack dev",
+        },
+      });
+    });
+
+    it("handles empty optional fields", async () => {
+      mockPrisma.userProfile.upsert.mockResolvedValue({});
+
+      const result = await createOrUpdateProfile({});
+
+      expect(result).toEqual({ success: true });
+      expect(mockPrisma.userProfile.upsert).toHaveBeenCalledWith({
+        where: { userId: "user-1" },
+        create: expect.objectContaining({
+          userId: "user-1",
+          currentRole: null,
+          yearsExperience: null,
+          company: null,
+          skills: [],
+          bio: null,
+        }),
+        update: expect.objectContaining({
+          currentRole: null,
+          yearsExperience: null,
+          company: null,
+          skills: [],
+          bio: null,
+        }),
+      });
+    });
+
+    it("returns error when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await createOrUpdateProfile({ bio: "test" });
+
+      expect(result).toEqual({ success: false, error: "Unauthorized" });
+    });
+
+    it("returns error when upsert fails", async () => {
+      mockPrisma.userProfile.upsert.mockRejectedValue(new Error("DB error"));
+
+      const result = await createOrUpdateProfile({ bio: "test" });
+
+      expect(result).toEqual({ success: false, error: "Failed to update profile" });
+    });
+  });
+
+  describe("getSkillsGained", () => {
+    it("returns skills array", async () => {
+      mockPrisma.userProfile.findUnique.mockResolvedValue({
+        skillsGained: ["React", "TypeScript"],
+      });
+
+      const result = await getSkillsGained();
+
+      expect(result).toEqual(["React", "TypeScript"]);
+    });
+
+    it("returns empty array when no profile", async () => {
+      mockPrisma.userProfile.findUnique.mockResolvedValue(null);
+
+      const result = await getSkillsGained();
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await getSkillsGained();
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/actions/tasks.test.ts
+++ b/tests/unit/actions/tasks.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Hoisted mock functions
+const { mockAuthFn, mockPrisma } = vi.hoisted(() => {
+  const createModelMock = () => ({
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    count: vi.fn().mockResolvedValue(0),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: 0 } }),
+  });
+  return {
+    mockAuthFn: vi.fn(),
+    mockPrisma: {
+      user: createModelMock(),
+      userProfile: createModelMock(),
+      category: createModelMock(),
+      goal: createModelMock(),
+      milestone: createModelMock(),
+      task: createModelMock(),
+      $transaction: vi.fn(async (args: unknown) => {
+        if (typeof args === "function") return (args as Function)(mockPrisma);
+        return Promise.all(args as Promise<unknown>[]);
+      }),
+    },
+  };
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: mockAuthFn,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockPrisma,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+// Import code under test
+import {
+  getTodayTasks,
+  createTask,
+  toggleTaskComplete,
+  updateTask,
+  deleteTask,
+  reorderTasks,
+} from "@/app/actions/tasks";
+
+const DEFAULT_SESSION = {
+  user: { id: "user-1", name: "Test User", email: "test@example.com", image: null },
+  expires: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("task actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthFn.mockResolvedValue(DEFAULT_SESSION);
+    mockPrisma.$transaction.mockImplementation(async (args: unknown) => {
+      if (typeof args === "function") return (args as Function)(mockPrisma);
+      return Promise.all(args as Promise<unknown>[]);
+    });
+  });
+
+  describe("getTodayTasks", () => {
+    it("returns empty array when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await getTodayTasks();
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns tasks and auto-creates tasks for milestones without tasks", async () => {
+      mockPrisma.task.findMany.mockResolvedValue([
+        { id: "task-1", title: "Quick task", milestoneId: null },
+      ]);
+      mockPrisma.milestone.findMany.mockResolvedValue([
+        {
+          id: "ms-1",
+          title: "Milestone due today",
+          notes: null,
+          dueDate: new Date(),
+          goal: { id: "g-1", title: "Goal", category: { name: "Cat", color: "#000" } },
+        },
+      ]);
+      mockPrisma.task.create.mockResolvedValue({
+        id: "task-2",
+        title: "Milestone due today",
+        milestoneId: "ms-1",
+      });
+
+      const result = await getTodayTasks();
+
+      expect(result).toHaveLength(2);
+      expect(mockPrisma.task.create).toHaveBeenCalledWith({
+        data: {
+          title: "Milestone due today",
+          notes: null,
+          dueDate: expect.any(Date),
+          milestoneId: "ms-1",
+          userId: "user-1",
+          position: 0,
+        },
+        include: expect.any(Object),
+      });
+    });
+  });
+
+  describe("createTask", () => {
+    it("creates an orphaned task", async () => {
+      mockPrisma.task.count.mockResolvedValue(0);
+      mockPrisma.task.aggregate.mockResolvedValue({ _max: { position: 5 } });
+      const task = { id: "task-1", title: "Buy groceries", milestoneId: null };
+      mockPrisma.task.create.mockResolvedValue(task);
+
+      const result = await createTask({ title: "Buy groceries" });
+
+      expect(result.success).toBe(true);
+      expect(result.task).toEqual(task);
+    });
+
+    it("enforces daily task limit", async () => {
+      mockPrisma.task.count.mockResolvedValue(20);
+
+      const result = await createTask({ title: "One more" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("20 quick tasks per day");
+    });
+
+    it("returns error when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await createTask({ title: "Test" });
+
+      expect(result).toEqual({ success: false, error: "Unauthorized" });
+    });
+  });
+
+  describe("toggleTaskComplete", () => {
+    it("marks incomplete task as complete", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue({
+        id: "task-1",
+        userId: "user-1",
+        completed: false,
+        milestoneId: null,
+      });
+      mockPrisma.task.update.mockResolvedValue({});
+
+      const result = await toggleTaskComplete("task-1");
+
+      expect(result.success).toBe(true);
+      expect(mockPrisma.task.update).toHaveBeenCalledWith({
+        where: { id: "task-1" },
+        data: {
+          completed: true,
+          completedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it("syncs completion to linked milestone", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue({
+        id: "task-1",
+        userId: "user-1",
+        completed: false,
+        milestoneId: "ms-1",
+        milestone: { id: "ms-1" },
+      });
+      mockPrisma.task.update.mockResolvedValue({});
+      mockPrisma.milestone.update.mockResolvedValue({});
+
+      await toggleTaskComplete("task-1");
+
+      expect(mockPrisma.milestone.update).toHaveBeenCalledWith({
+        where: { id: "ms-1" },
+        data: {
+          status: "COMPLETED",
+          completedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it("uncompletes task and resets milestone", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue({
+        id: "task-1",
+        userId: "user-1",
+        completed: true,
+        milestoneId: "ms-1",
+        milestone: { id: "ms-1" },
+      });
+      mockPrisma.task.update.mockResolvedValue({});
+      mockPrisma.milestone.update.mockResolvedValue({});
+
+      await toggleTaskComplete("task-1");
+
+      expect(mockPrisma.milestone.update).toHaveBeenCalledWith({
+        where: { id: "ms-1" },
+        data: {
+          status: "PENDING",
+          completedAt: null,
+        },
+      });
+    });
+
+    it("returns error when task not found", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue(null);
+
+      const result = await toggleTaskComplete("task-999");
+
+      expect(result).toEqual({ success: false, error: "Task not found" });
+    });
+
+    it("returns error when task owned by another user", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue({
+        id: "task-1",
+        userId: "other-user",
+      });
+
+      const result = await toggleTaskComplete("task-1");
+
+      expect(result).toEqual({ success: false, error: "Task not found" });
+    });
+  });
+
+  describe("updateTask", () => {
+    it("updates task title and notes", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue({
+        id: "task-1",
+        userId: "user-1",
+        title: "Old",
+        notes: "Old notes",
+      });
+      mockPrisma.task.update.mockResolvedValue({});
+
+      const result = await updateTask("task-1", { title: "New", notes: "New notes" });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("returns error when task not found", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue(null);
+
+      const result = await updateTask("task-999", { title: "Test" });
+
+      expect(result).toEqual({ success: false, error: "Task not found" });
+    });
+  });
+
+  describe("deleteTask", () => {
+    it("deletes orphaned task", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue({
+        id: "task-1",
+        userId: "user-1",
+        milestoneId: null,
+      });
+      mockPrisma.task.delete.mockResolvedValue({});
+
+      const result = await deleteTask("task-1");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects deletion of milestone-linked tasks", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue({
+        id: "task-1",
+        userId: "user-1",
+        milestoneId: "ms-1",
+      });
+
+      const result = await deleteTask("task-1");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("milestone-linked");
+    });
+
+    it("returns error when task not found", async () => {
+      mockPrisma.task.findUnique.mockResolvedValue(null);
+
+      const result = await deleteTask("task-999");
+
+      expect(result).toEqual({ success: false, error: "Task not found" });
+    });
+  });
+
+  describe("reorderTasks", () => {
+    it("updates positions in a transaction", async () => {
+      mockPrisma.task.update.mockResolvedValue({});
+
+      const result = await reorderTasks(["task-2", "task-1", "task-3"]);
+
+      expect(result.success).toBe(true);
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it("returns error when not authenticated", async () => {
+      mockAuthFn.mockResolvedValue(null);
+
+      const result = await reorderTasks(["task-1"]);
+
+      expect(result).toEqual({ success: false, error: "Unauthorized" });
+    });
+  });
+});

--- a/tests/unit/lib/gemini.test.ts
+++ b/tests/unit/lib/gemini.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("gemini module", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  describe("isAIAvailable", () => {
+    it("returns true when GOOGLE_AI_API_KEY is set", async () => {
+      vi.stubEnv("GOOGLE_AI_API_KEY", "test-key");
+      const { isAIAvailable } = await import("@/lib/ai/gemini");
+      expect(isAIAvailable()).toBe(true);
+      vi.unstubAllEnvs();
+    });
+
+    it("returns false when GOOGLE_AI_API_KEY is not set", async () => {
+      vi.stubEnv("GOOGLE_AI_API_KEY", "");
+      const { isAIAvailable } = await import("@/lib/ai/gemini");
+      expect(isAIAvailable()).toBe(false);
+      vi.unstubAllEnvs();
+    });
+  });
+
+  describe("getFlashModel", () => {
+    it("throws when API key is not set", async () => {
+      vi.stubEnv("GOOGLE_AI_API_KEY", "");
+      const { getFlashModel } = await import("@/lib/ai/gemini");
+      expect(() => getFlashModel()).toThrow("GOOGLE_AI_API_KEY");
+      vi.unstubAllEnvs();
+    });
+  });
+
+  describe("getProModel", () => {
+    it("throws when API key is not set", async () => {
+      vi.stubEnv("GOOGLE_AI_API_KEY", "");
+      const { getProModel } = await import("@/lib/ai/gemini");
+      expect(() => getProModel()).toThrow("GOOGLE_AI_API_KEY");
+      vi.unstubAllEnvs();
+    });
+  });
+});

--- a/tests/unit/lib/utils.test.ts
+++ b/tests/unit/lib/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "@/lib/utils";
+
+describe("cn utility", () => {
+  it("merges class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("handles conditional classes", () => {
+    expect(cn("base", false && "hidden", "visible")).toBe("base visible");
+  });
+
+  it("resolves tailwind conflicts (last wins)", () => {
+    const result = cn("px-2 py-1", "px-4");
+    expect(result).toBe("py-1 px-4");
+  });
+
+  it("handles undefined and null inputs", () => {
+    expect(cn("base", undefined, null, "end")).toBe("base end");
+  });
+
+  it("handles empty call", () => {
+    expect(cn()).toBe("");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+const alias = {
+  "@": path.resolve(__dirname, "."),
+};
+
+export default defineConfig({
+  resolve: { alias },
+  test: {
+    projects: [
+      {
+        resolve: { alias },
+        test: {
+          name: "unit",
+          environment: "jsdom",
+          include: [
+            "tests/unit/**/*.test.{ts,tsx}",
+            "tests/components/**/*.test.{ts,tsx}",
+          ],
+          setupFiles: ["./tests/setup.ts"],
+        },
+      },
+      {
+        resolve: { alias },
+        test: {
+          name: "integration",
+          environment: "node",
+          include: ["tests/integration/**/*.test.ts"],
+          setupFiles: ["./tests/setup.ts"],
+        },
+      },
+    ],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "json", "html"],
+      thresholds: {
+        statements: 95,
+        branches: 95,
+        functions: 95,
+        lines: 95,
+      },
+      exclude: [
+        "components/ui/**",
+        "node_modules/**",
+        ".next/**",
+        "prisma/**",
+        "**/*.config.*",
+        "**/*.d.ts",
+        "tests/**",
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- **Updated PLAN.md** with the full Questive three-pillar roadmap (Production Readiness → AI Improvements → Complementary Features)
- **Set up Vitest 4** with jsdom for unit tests and node for integration tests, configured via `vitest.config.ts` with two projects (`unit`, `integration`)
- **Added 122 passing tests** across 14 test files covering all server actions, lib modules, interactive components, integration flows, and an e2e smoke test
- **Added 6 npm scripts**: `test`, `test:watch`, `test:coverage`, `test:integration`, `test:smoke`, `typecheck`
- **Coverage thresholds** set at 95% (statements, branches, functions, lines) excluding shadcn/ui vendor code

### Test breakdown

| Category | Files | Tests |
|----------|-------|-------|
| Server actions (account, categories, goals, milestones, tasks, ai, profile) | 7 | 92 |
| Lib (utils, gemini) | 2 | 9 |
| Components (ai-suggest-button, goal-card, create-task-input, delete-account-dialog) | 4 | 20 |
| Integration (goal lifecycle) | 1 | 1 |
| E2e smoke (production canary) | 1 | 4 |

## Test plan

- [x] `npm test` — all 121 unit tests pass
- [x] `npm run test:integration` — integration test passes
- [x] `npm run test:coverage` — verify coverage report generates correctly
- [x] `npm run typecheck` — verify no type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)